### PR TITLE
Update board styling

### DIFF
--- a/src/components/BoardControls/BoardControls.tsx
+++ b/src/components/BoardControls/BoardControls.tsx
@@ -49,16 +49,18 @@ export class BoardControls extends React.Component<BoardControlsProps, BoardCont
     let boardTitle;
     if (this.state.isEditingTitle) {
       boardTitle = (
-        <>
-          <input type="text" defaultValue={this.props.title} ref={this.titleInput}></input>
-          <button onClick={this.saveTitle.bind(this)}>Save</button>
-          <a href="" onClick={event => this.editTitle(event)}>cancel</a>
-        </>
+        <div id="board-title">
+          <input className="board-title--text" type="text" autoFocus={true} defaultValue={this.props.title} ref={this.titleInput}></input>
+          <div className="board-title--actions">
+            <button onClick={this.saveTitle.bind(this)}>Save</button>
+            <a href="" onClick={event => this.editTitle(event)}>cancel</a>
+          </div>
+        </div>
       );
     } else {
       boardTitle = (
         <div id="board-title">
-          <h1>
+          <h1 className="board-title--text">
             {this.props.title} <FontAwesomeIcon icon={faPencilAlt} className="pencil-icon" onClick={() => this.editTitle()} />
           </h1>
         </div>

--- a/src/components/BoardControls/BoardControls.tsx
+++ b/src/components/BoardControls/BoardControls.tsx
@@ -66,9 +66,9 @@ export class BoardControls extends React.Component<BoardControlsProps, BoardCont
     }
 
     return (
-      <div className="board-controls">
+      <div id="board-controls">
         { boardTitle }
-        <div id="board-controls">
+        <div className="board-actions">
           <button
             className="button button--create"
             onClick={() => this.props.addColumn()}

--- a/src/components/BoardControls/board-controls.css
+++ b/src/components/BoardControls/board-controls.css
@@ -1,10 +1,11 @@
-.board-controls {
+#board-controls {
   margin: 0 20px;
   grid-row: 1 / span 1;
   display: grid;
   grid-template-columns: repeat(12, 1fr);
   grid-column: 1 / span 12;
   height: max-content;
+  align-items: center;
 }
 
 #board-title {
@@ -27,13 +28,10 @@
   padding: 5px 0px;
 }
 
-#board-controls {
+.board-actions {
   grid-row: 1 / span 1;
   grid-column: 11 / span 2;
   text-align: right;
-}
-#board-controls > .button--create {
-  height: 100%;
 }
 
 .stars-remaining {

--- a/src/components/BoardControls/board-controls.css
+++ b/src/components/BoardControls/board-controls.css
@@ -12,6 +12,7 @@
   grid-row: 1 / span 1;
   grid-column: 1 / span 2;
   height: 100%;
+  position: relative;
 }
 
 #board-title .pencil-icon {
@@ -23,9 +24,13 @@
   display: inline-block;
 }
 
-#board-title > h2 {
+.board-title--text {
+  display: block;
   margin: 0;
   padding: 5px 0px;
+  font-size: 1.4rem;
+  font-weight: 600;
+  border: none;
 }
 
 .board-actions {

--- a/src/components/ButtonDelete/ButtonDelete.tsx
+++ b/src/components/ButtonDelete/ButtonDelete.tsx
@@ -1,10 +1,10 @@
-import React, { MouseEvent, ReactText } from "react";
+import React, { MouseEvent } from "react";
 import { faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import "./button-delete.css";
 interface ButtonDeleteProps {
-  id: ReactText;
-  handleClick: (event: MouseEvent, id: ReactText) => void;
+  id: string;
+  handleClick: (event: MouseEvent, id: string) => void;
 }
 
 export const ButtonDelete = (props: ButtonDeleteProps) => (

--- a/src/components/Card/card.css
+++ b/src/components/Card/card.css
@@ -23,6 +23,7 @@
 .card-container .card--text,
 .card-container textarea {
   margin: 1rem 0;
+  min-height: 40px;
 }
 
 .card-container textarea {
@@ -65,6 +66,10 @@
   display: flex;
   flex-direction: row;
   align-items: center;
+}
+
+.card--footer button[type="submit"] {
+  font-size: 14pt;
 }
 
 .button--delete {

--- a/src/components/Column/Column.tsx
+++ b/src/components/Column/Column.tsx
@@ -5,7 +5,6 @@ import { Card } from "../Card/Card";
 import * as uuid from "uuid";
 import { ColumnHeader } from "../ColumnHeader/ColumnHeader";
 import "./column.css";
-import { ButtonDelete } from "../ButtonDelete/ButtonDelete";
 
 interface CardData {
   id: string;
@@ -164,13 +163,14 @@ export class Column extends React.Component<ColumnProps, ColumnState> {
       >
         <div className="header-row">
           <ColumnHeader
+            columnId={this.props.id}
             isEditing={this.state.isEditing}
             name={this.state.name}
             nameInputRef={this.nameInput}
             onEditToggle={(e) => this.toggleIsEditing(e)}
             onSubmit={(e) => this.updateColumnName(e)}
+            onDeleteClick={(event, id) => this.props.deleteColumn(event, id)}
           />
-          { this.state.isEditing ? <ButtonDelete id={this.props.id} handleClick={(event, id) => this.props.deleteColumn(event, id as string)}/> : null }
         </div>
         <div className="body-row">
           <button onClick={() => this.addCard()}>

--- a/src/components/Column/column.css
+++ b/src/components/Column/column.css
@@ -5,7 +5,7 @@
 
 .column {
   flex-grow: 1;
-  margin: 20px;
+  margin: 20px 10px;
 }
 
 .column-edit > input {

--- a/src/components/ColumnHeader/ColumnHeader.tsx
+++ b/src/components/ColumnHeader/ColumnHeader.tsx
@@ -1,15 +1,18 @@
 import React, { FormEvent, RefObject, MouseEvent } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPencilAlt } from "@fortawesome/free-solid-svg-icons";
+import { ButtonDelete } from "../ButtonDelete/ButtonDelete";
 
 import "./column-header.css";
 
 interface ColumnHeaderProps {
+  columnId: string;
   isEditing: boolean;
   name?: string;
   nameInputRef: RefObject<HTMLInputElement>
   onSubmit: (e: FormEvent) => void;
   onEditToggle: (e: MouseEvent) => void;
+  onDeleteClick: (e: MouseEvent, id: string) => void;
 }
 
 export const ColumnHeader = (props: ColumnHeaderProps) => {
@@ -20,19 +23,21 @@ export const ColumnHeader = (props: ColumnHeaderProps) => {
         onSubmit={event => props.onSubmit(event)}
       >
         <input
+          className="column-header--text"
           type="text"
           defaultValue={props.name}
           ref={props.nameInputRef}
           autoFocus={true}
         />
         <button type="submit">Save</button>
-        <button type="button" onClick={event => props.onEditToggle(event)}>cancel</button>
+        <button type="button" onClick={event => props.onEditToggle(event)}>Cancel</button>
+        <ButtonDelete id={props.columnId} handleClick={(e, id) => props.onDeleteClick(e, id)}/>
       </form>
     );
   } else {
     return (
       <h2
-        className="column-header"
+        className="column-header column-header--text"
         onClick={event => props.onEditToggle(event)}
       >
         {props.name}&nbsp;<FontAwesomeIcon className="pencil-icon" icon={faPencilAlt} />

--- a/src/components/ColumnHeader/column-header.css
+++ b/src/components/ColumnHeader/column-header.css
@@ -1,7 +1,20 @@
 .column-header {
   flex: 0 0 auto;
+  margin: 1.0rem 0;
+  width: 100%;
+}
+
+.column-header--text {
+  display: block;
+  padding: 0;
+  border: 0;
   font-size: 1.5em;
-  margin: 1.0em 0;
+  font-weight: 600;
+  width: 100%;
+}
+
+.column-header--editing .column-header--text {
+  margin-bottom: 0.5rem;
 }
 
 .column-header > .pencil-icon {

--- a/src/components/Main/main.css
+++ b/src/components/Main/main.css
@@ -10,4 +10,5 @@ main {
   grid-column: 1 / span 12;
   display: flex;
   padding-top: 20px;
+  margin: 0 10px;
 }


### PR DESCRIPTION
Updates so so that when cards, column headers or the retro title are edited, they do not jump around in the UI so much. Other minor tweaks as well such as changing the height of the create column button and autofocusing the text input for the retro title when it is selected to be edited.