### PR TITLE
Update App so that when the board is loaded, the correct state Results state is set

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -59,6 +59,7 @@ function emitBoardLoaded(socket: SocketIO.Socket, boardId: string, sessionId: st
   socket.emit(`board:loaded:${boardId}`, {
     board: boards[boardId],
     sessionId,
+    showResults: boards[boardId].showResults,
     remainingStars: sessionStore[sessionId].remainingStars[boardId],
   });
 }

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -40,10 +40,10 @@ export class App extends React.Component<{}, AppState> {
 
   componentDidMount() {
     const sessionId = sessionStorage.getItem("retroSessionId");
-
-    this.state.socket.emit("board:loaded", {
-      boardId: this.state.boardId,
-      sessionId,
+    this.state.socket.on(`board:loaded:${this.state.boardId}`, (
+      data: { board: Board, sessionId: string, remainingStars: number, showResults: boolean },
+    ) => {
+      this.setState({ showResults: data.showResults });
     });
     this.state.socket.on(`board:star-limit-reached:${this.state.boardId}`, (data: { maxStars: number }) => {
       this.displayStarLimitAlert(data.maxStars);
@@ -51,6 +51,11 @@ export class App extends React.Component<{}, AppState> {
 
     this.state.socket.on(`board:show-results:${this.state.boardId}`, (data: { showResults: boolean }) => {
       this.setState({showResults: data.showResults})
+    });
+
+    this.state.socket.emit("board:loaded", {
+      boardId: this.state.boardId,
+      sessionId,
     });
   }
 

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -23,12 +23,12 @@ export class Main extends React.Component<MainProps, MainState> {
     this.state = {
       columns: [],
       boardTitle: "",
-    }
+    };
   }
 
   componentDidMount() {
     this.props.socket.on(`board:loaded:${this.props.boardId}`, (
-      data: { board: Board, sessionId: string, remainingStars: number },
+      data: { board: Board, sessionId: string, remainingStars: number, showResults: boolean },
     ) => {
       this.setState({
         remainingStars: data.remainingStars,


### PR DESCRIPTION
1. When the board is loaded, this change ensures that the correct state of "results visible" ("hidden" or "shown") is set. 