### PR TITLE
Install "open" as a dependency and us it to open the ngrok url automatically

### DIFF
--- a/ngrok.ts
+++ b/ngrok.ts
@@ -2,6 +2,7 @@ import ngrok from "ngrok";
 
 if(process.env.NODE_ENV === "production") {
   (async function() {
+    const open = require("open");
     const url = await ngrok.connect({
       proto: 'http',
       addr: 8000,
@@ -9,5 +10,14 @@ if(process.env.NODE_ENV === "production") {
 
     console.log('Tunnel Created -> \x1b[34m%s\x1b[0m', url);
     console.log('Tunnel Inspector ->  http://127.0.0.1:4040');
+
+    // Opens the URL in the default browser.
+    try {
+      await open(url);
+    } catch {
+      console.warn(
+        `Unable to open "${url}" in browser.`
+      );
+    }
   })();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4393,6 +4393,11 @@
         }
       }
     },
+    "is-docker": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
+      "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ=="
+    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -5315,6 +5320,22 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "open": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.0.2.tgz",
+      "integrity": "sha512-70E/pFTPr7nZ9nLDPNTcj3IVqnNvKuP4VsBmoKV9YGTnChe0mlS3C4qM7qKarhZ8rGaHKLfo+vBTHXDp6ZSyLQ==",
+      "requires": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "dependencies": {
+        "is-wsl": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
+          "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog=="
+        }
       }
     },
     "opn": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@fortawesome/react-fontawesome": "^0.1.7",
     "express": "^4.17.1",
     "ngrok": "^3.2.5",
+    "open": "7.0.2",
     "react": "^16.11.0",
     "react-dom": "^16.11.0",
     "socket.io": "^2.3.0",


### PR DESCRIPTION
[`open`](https://github.com/sindresorhus/open) is the same library that[ is used to open the browser when using the `--open` flag with `webpack-dev-server`](https://github.com/webpack/webpack-dev-server/blob/2da4a1e0328f8271a0b9b5ec40dcafeb231cfb09/lib/utils/runOpen.js#L25).

This makes it more clear to someone starting up the app, what the production link is.