### PR TITLE
Install dependencies for overmind

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -854,6 +854,22 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "betsy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/betsy/-/betsy-1.0.2.tgz",
+      "integrity": "sha512-yt/OUTbSeCRj4uwbDnjTbnWgrLsgBl1nzJLdZH2eOtrf3SDH7svdoTMWOvTFhUdIM86pY6k21o/4SCIT6RYjig==",
+      "requires": {
+        "@types/node": "^10.5.1",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.16",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.16.tgz",
+          "integrity": "sha512-A4283YSA1OmnIivcpy/4nN86YlnKRiQp8PYwI2KdPCONEBN093QTb0gCtERtkLyVNGKKIGazTZ2nAmVzQU51zA=="
+        }
+      }
+    },
     "better-assert": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
@@ -4464,6 +4480,11 @@
         "path-is-inside": "^1.0.2"
       }
     },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -5373,6 +5394,25 @@
         "mem": "^4.0.0"
       }
     },
+    "overmind": {
+      "version": "22.0.5",
+      "resolved": "https://registry.npmjs.org/overmind/-/overmind-22.0.5.tgz",
+      "integrity": "sha512-QcgdC6QzJtUl1diUZQFRlgt2Tx5Z5RGF3K1q7mfyvCO93ceUaB7iDUFxi0Tm3dI0PeJypOqmRbn6salI5/oz2w==",
+      "requires": {
+        "betsy": "1.0.2",
+        "is-plain-obj": "^1.1.0",
+        "proxy-state-tree": "4.7.0",
+        "tslib": "^1.10.0"
+      }
+    },
+    "overmind-react": {
+      "version": "23.0.5",
+      "resolved": "https://registry.npmjs.org/overmind-react/-/overmind-react-23.0.5.tgz",
+      "integrity": "sha512-2IAy+8UaC4tlGGYRQlm1vZex/kNdz8+AArjCA9Cb5JgOU6yIXMoIoBniPkThVwXgrZHyiwS2BQFyEskIUwKHrg==",
+      "requires": {
+        "overmind": "22.0.5"
+      }
+    },
     "p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
@@ -5797,6 +5837,14 @@
       "requires": {
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.0"
+      }
+    },
+    "proxy-state-tree": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/proxy-state-tree/-/proxy-state-tree-4.7.0.tgz",
+      "integrity": "sha512-kMdNHOmxC3hNe5jhNu8MbFjAAHIvSGTD9vxQtHq49AyXLCbRPrKkAlJINqRZ6hiXOespCOTT6QfveAcSYC2rwQ==",
+      "requires": {
+        "is-plain-obj": "^1.1.0"
       }
     },
     "prr": {
@@ -7574,8 +7622,7 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "dev": true
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "express": "^4.17.1",
     "ngrok": "^3.2.5",
     "open": "7.0.2",
+    "overmind": "22.0.5",
+    "overmind-react": "23.0.5",
     "react": "^16.11.0",
     "react-dom": "^16.11.0",
     "socket.io": "^2.3.0",


### PR DESCRIPTION
Adds dependencies that will be used to add simple state management to the app. 

- [Overmind docs](https://overmindjs.org/)

Added as the complexity of managing callbacks being passed through to child components and prop drilling was becoming less and less manageable.