### PR TITLE
Immediately update the remaining star count when a card or column is deleted

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,5 @@ interface BoardColumn {
 
 interface Session {
   id: string;
-  remainingStars: {
-    [boardId: string]: number;
-  }
+  remainingStars: number;
 }

--- a/server.ts
+++ b/server.ts
@@ -293,6 +293,7 @@ io.on('connection', function (socket) {
         column.cards.splice(cardIndex, 1);
 
         reclaimStarsFromDeleteCard(card, data.boardId);
+        emitUpdateRemainingStars(socket, data.boardId, data.sessionId);
 
         socket.broadcast.emit(`card:deleted:${data.columnId}`, {
           id: data.id

--- a/server.ts
+++ b/server.ts
@@ -4,7 +4,9 @@ import uuid from "uuid";
 
 let boards: {[key: string]: Board} = {};
 let sessionStore: {
-  [id: string]: Session;
+  [boardId: string]: {
+    [id: string]: Session
+  };
 } = {};
 
 const MAX_VOTES_USER_VOTE_PER_BOARD = 10;
@@ -51,7 +53,7 @@ function createNewBoard(boardId?: string) {
 
 function reclaimStarsFromDeleteCard(card: Card, boardId: string) {
   Object.keys(card.stars).forEach(sessionId => {
-    sessionStore[sessionId].remainingStars[boardId] += Math.abs(card.stars[sessionId]);
+    sessionStore[boardId][sessionId].remainingStars += Math.abs(card.stars[sessionId]);
   });
 }
 
@@ -60,13 +62,13 @@ function emitBoardLoaded(socket: SocketIO.Socket, boardId: string, sessionId: st
     board: boards[boardId],
     sessionId,
     showResults: boards[boardId].showResults,
-    remainingStars: sessionStore[sessionId].remainingStars[boardId],
+    remainingStars: sessionStore[boardId][sessionId].remainingStars,
   });
 }
 
 function initializeBoardForUser(boardId: string, sessionId: string) {
   boardId = createNewBoard(boardId);
-  sessionStore[sessionId].remainingStars[boardId] = MAX_VOTES_USER_VOTE_PER_BOARD;
+  sessionStore[boardId][sessionId].remainingStars = MAX_VOTES_USER_VOTE_PER_BOARD;
 }
 
 function updateRemainingStars(
@@ -82,21 +84,17 @@ function updateRemainingStars(
 
   // Check if the star undoes a previous one and adds a remaining star back.
   if((star < 0 && card.stars[session.id] > 0)) {
-    session.remainingStars[boardId]++;
+    session.remainingStars++;
     card.starsCount--;
     card.stars[session.id]--;
-  } else if (star > 0 && session.remainingStars[boardId] > 0){
-    session.remainingStars[boardId]--;
+  } else if (star > 0 && session.remainingStars > 0){
+    session.remainingStars--;
     card.starsCount++;
     card.stars[session.id]++;
   } else {
     console.log("No more stars left");
     socket.emit(`board:star-limit-reached:${boardId}`, { maxStars: MAX_VOTES_USER_VOTE_PER_BOARD });
   }
-}
-
-function newBoardSession(session: Session, boardId: string) {
-  return session.remainingStars[boardId] === undefined;
 }
 
 function canStar(remainingStars: number) {
@@ -121,18 +119,21 @@ io.on('connection', function (socket) {
 
   socket.on('board:loaded', function (data: { boardId: string, sessionId?: string }) {
     let sessionId = data.sessionId ?? uuid.v4();
+    const newSession = {
+      id: sessionId,
+      remainingStars: MAX_VOTES_USER_VOTE_PER_BOARD,
+    };
 
-    if(!sessionStore[sessionId]) {
-      sessionStore[sessionId] = {
-        id: sessionId,
-        remainingStars: {},
+    if(!sessionStore[data.boardId]) {
+      sessionStore[data.boardId] = {
+        [sessionId]: newSession,
       };
+    } else if (!sessionStore[data.boardId][sessionId]) {
+      sessionStore[data.boardId][sessionId] = newSession
     }
 
     if(!data.boardId || !boards[data.boardId]) {
       initializeBoardForUser(data.boardId, sessionId);
-    } else if (newBoardSession(sessionStore[sessionId], data.boardId)) {
-      sessionStore[sessionId].remainingStars[data.boardId] = MAX_VOTES_USER_VOTE_PER_BOARD
     }
 
     emitBoardLoaded(socket, data.boardId, sessionId);
@@ -153,7 +154,7 @@ io.on('connection', function (socket) {
 
   socket.on("column:loaded", function(data: { boardId: string, id: string, sessionId: string }) {
     console.log("column load request");
-    if (data.sessionId === undefined && !sessionStore[data.sessionId]) {
+    if (data.sessionId === undefined && !sessionStore[data.boardId][data.sessionId]) {
       console.error("No session");
       return;
     }
@@ -174,7 +175,7 @@ io.on('connection', function (socket) {
 
   socket.on("column:created", function(data: { boardId: string, id: string, name: string, sessionId: string }) {
     console.log("column create request");
-    if (data.sessionId === undefined && !sessionStore[data.sessionId]) {
+    if (data.sessionId === undefined && !sessionStore[data.boardId][data.sessionId]) {
       console.error("No session");
       return;
     }
@@ -188,7 +189,7 @@ io.on('connection', function (socket) {
 
   socket.on("column:updated", function(data: { boardId: string, id: string, name: string, sessionId: string }) {
     console.log("column update request");
-    if (data.sessionId === undefined && !sessionStore[data.sessionId]) {
+    if (data.sessionId === undefined && !sessionStore[data.boardId][data.sessionId]) {
       console.error("No session");
       return;
     }
@@ -201,30 +202,31 @@ io.on('connection', function (socket) {
     }
   });
 
-  socket.on("column:deleted", function(data: { boardId: string, id: string, sessionId: string }) {
+  socket.on("column:deleted", function({ boardId, sessionId, id }: { boardId: string, id: string, sessionId: string }) {
     console.log("column delete request");
-    if (data?.sessionId === undefined && !sessionStore[data.sessionId]) {
+    if (sessionId === undefined && !sessionStore[boardId][sessionId]) {
       console.error("No session");
       return;
     }
 
-    console.log(data);
-    let columnIndex = boards[data.boardId].columns.findIndex((column) => column.id === data.id);
+    let columnIndex = boards[boardId].columns.findIndex((column) => column.id === id);
     if (columnIndex) {
-      const column = boards[data.boardId].columns[columnIndex];
+      const column = boards[boardId].columns[columnIndex];
 
-      column?.cards?.forEach((card) => { reclaimStarsFromDeleteCard(card, data.boardId); });
+      column?.cards?.forEach((card) => { reclaimStarsFromDeleteCard(card, boardId); });
 
-      boards[data.boardId]?.columns.splice(columnIndex, 1);
-      socket.broadcast.emit(`column:deleted:${data.boardId}`, {
-        id: data.id
+      socket.emit(`board:update-remaining-stars:${boardId}`, {
+        remainingStars: sessionStore[boardId][sessionId].remainingStars,
       });
+
+      boards[boardId]?.columns.splice(columnIndex, 1);
+      socket.broadcast.emit(`column:deleted:${boardId}`, { id });
     }
   })
 
   socket.on("card:created", function(data: { boardId: string, columnId: string, id: string, text: string, sessionId: string }) {
     console.log("card create request")
-    if (data.sessionId === undefined && !sessionStore[data.sessionId]) {
+    if (data.sessionId === undefined && !sessionStore[data.boardId][data.sessionId]) {
       console.error("No session");
       return;
     }
@@ -251,7 +253,7 @@ io.on('connection', function (socket) {
 
   socket.on("card:updated", function (data: { boardId: string, columnId: string, id: string, text: string, sessionId: string }) {
     console.log("card update request");
-    if (data.sessionId === undefined && !sessionStore[data.sessionId]) {
+    if (data.sessionId === undefined && !sessionStore[data.boardId][data.sessionId]) {
       console.error("No session");
       return;
     }
@@ -270,7 +272,7 @@ io.on('connection', function (socket) {
 
   socket.on("card:deleted", function (data: { boardId: string, columnId: string, id: string, sessionId: string }) {
     console.log("card delete request");
-    if (data.sessionId === undefined && !sessionStore[data.sessionId]) {
+    if (data.sessionId === undefined && !sessionStore[data.boardId][data.sessionId]) {
       console.error("No session");
       return;
     }
@@ -294,16 +296,16 @@ io.on('connection', function (socket) {
 
   socket.on("card:starred", function ({ id, star, boardId, columnId, sessionId }: { id: string, star: number, boardId: string, columnId: string, sessionId: string }) {
     console.log("star for card request");
-    if (sessionId === undefined && !sessionStore[sessionId]) {
+    if (sessionId === undefined && !sessionStore[boardId][sessionId]) {
       console.error("No session");
       return;
     }
-    const session = sessionStore[sessionId];
+    const session = sessionStore[boardId][sessionId];
 
     const column = boards[boardId].columns.find((column) => column.id === columnId);
     if (column) {
       const card = column.cards.find((card) => card.id === id);
-      if (card && canStar(session.remainingStars[boardId])) {
+      if (card && canStar(session.remainingStars)) {
         updateRemainingStars(session, socket, card, boardId, star);
         const userStars = card.stars[session.id];
         const { starsCount } = card;
@@ -313,7 +315,7 @@ io.on('connection', function (socket) {
           starsCount,
         });
         socket.emit(`board:update-remaining-stars:${boardId}`, {
-          remainingStars: session.remainingStars[boardId],
+          remainingStars: session.remainingStars,
         });
       }
     }

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -27,7 +27,7 @@ export const App = () => {
 
   const socket = io.connect(serverURL);
   const [boardId] = useState(initialBoardId);
-  const [maxStars, setMaxStars] = useState();
+  const [maxStars, setMaxStars] = useState(null as unknown as number);
   const [showStarLimitAlert, updateShowStarLimitAlert] = useState(false);
 
   function setHideStarLimitAlertTimeout(timeoutMS = 3000) {

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo } from "react";
 import { Column } from "../Column/Column";
 import uuid = require("uuid");
 import { BoardControls } from "../BoardControls/BoardControls";
+import { useOvermind } from "../../overmind";
 
 import "./main.css";
 
@@ -17,7 +18,7 @@ export enum SortDirection {
 };
 
 export const Main = (props: MainProps) => {
-  const [columns, updateColumns] = React.useState([] as BoardColumn[]);
+  const { state: { columns }, actions } = useOvermind();
   const [boardTitle, updateBoardTitle] = React.useState("" as string);
   const [sortDirection, updateSortDirection] = React.useState(SortDirection.desc);
   const [remainingStars, updateRemainingStars] = React.useState(null as unknown as number);
@@ -30,14 +31,13 @@ export const Main = (props: MainProps) => {
       updateRemainingStars(data.remainingStars);
       sessionStorage.setItem("retroSessionId", data.sessionId);
 
-      updateColumns(
-        data.board.columns.map((column: { id: string; name: string; }) => (
-          { id: column.id, name: column.name, isEditing: false }
-        )),
-      );
+      const initialColumns = data.board.columns.map((column: { id: string; name: string; }) => ({
+        ...column,
+        isEditing: false
+      }));
+      actions.setColumns(initialColumns);
 
       props.socket.on(`board:update-remaining-stars:${props.boardId}:${data.sessionId}`, (data: any) => {
-        console.log("UPDATE REMAINING STARS")
         updateRemainingStars(data.remainingStars);
       });
     });
@@ -60,7 +60,7 @@ export const Main = (props: MainProps) => {
       props.socket.removeListener(`column:deleted:${props.boardId}`);
       props.socket.removeListener(`column:created:${props.boardId}`);
     };
-  }, []);
+  }, [columns]);
 
   const sortColumnCardsByStars = () => {
     let newSortDirection = SortDirection.none;
@@ -92,10 +92,7 @@ export const Main = (props: MainProps) => {
       boardColumn = { id: uuid.v4(), name: "New Column", isEditing: true, new: true };
     }
 
-    updateColumns([
-      ...columns,
-      boardColumn,
-    ]);
+    actions.addColumn(boardColumn);
   }
 
   function renderColumns() {
@@ -145,9 +142,11 @@ export const Main = (props: MainProps) => {
       event.preventDefault();
     }
 
-    let newColumns = columns.filter((column: BoardColumn) => {
-      return column.id !== id;
-    });
+    for (let i = 0; i < columns.length; i++) {
+      if (columns[i].id === id) {
+        actions.deleteColumn(columns[i]);
+      }
+    }
 
     if (!fromSocket) {
       props.socket.emit(`column:deleted`, {
@@ -156,9 +155,11 @@ export const Main = (props: MainProps) => {
         sessionId: sessionStorage.getItem("retroSessionId"),
       });
     }
-
-    updateColumns(newColumns);
   }
+
+  const memoizedColumns = useMemo(() => {
+    return renderColumns();
+  }, [columns]);
 
   return (
     <main>
@@ -171,7 +172,7 @@ export const Main = (props: MainProps) => {
         sortDirection={sortDirection}
       />
       <div id="columns">
-        {renderColumns()}
+        { memoizedColumns }
       </div>
     </main>
   );

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -35,16 +35,16 @@ export const Main = (props: MainProps) => {
           { id: column.id, name: column.name, isEditing: false }
         )),
       );
+
+      props.socket.on(`board:update-remaining-stars:${props.boardId}:${data.sessionId}`, (data: any) => {
+        console.log("UPDATE REMAINING STARS")
+        updateRemainingStars(data.remainingStars);
+      });
     });
 
     props.socket.on(`board:updated:${props.boardId}`, (data: any) => {
       updateBoardTitle(data.title);
     });
-
-    props.socket.on(`board:update-remaining-stars:${props.boardId}`, (data: any) => {
-      console.log("UPDATE REMAINING STARS")
-      updateRemainingStars(data.remainingStars);
-    })
 
     props.socket.on(`column:created:${props.boardId}`, (data: any) => {
       addColumn(data);

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -42,6 +42,7 @@ export const Main = (props: MainProps) => {
     });
 
     props.socket.on(`board:update-remaining-stars:${props.boardId}`, (data: any) => {
+      console.log("UPDATE REMAINING STARS")
       updateRemainingStars(data.remainingStars);
     })
 

--- a/src/overmind/actions/index.ts
+++ b/src/overmind/actions/index.ts
@@ -1,6 +1,28 @@
 import { AppMode } from "../state";
-import { Action } from "overmind";
+import { Action, mutate } from "overmind";
 
 export const updateMode: Action<AppMode> = ({ state }, mode: AppMode) => {
   state.mode = mode;
+};
+
+export const addColumn = mutate(function setColumns({ state }, column: BoardColumn) {
+  state.columns = [
+    ...state.columns,
+    column,
+  ];
+});
+
+export const deleteColumn = mutate(function setColumns({ state }, column: BoardColumn) {
+  const copy = [
+    ...state.columns
+  ];
+  const index = copy.indexOf(column);
+  if (index !== -1) {
+    copy.splice(index, 1);
+    state.columns = copy;
+  }
+});
+
+export const setColumns: Action<BoardColumn[]> = ({ state }, columns: BoardColumn[]) => {
+  state.columns = columns;
 };

--- a/src/overmind/index.ts
+++ b/src/overmind/index.ts
@@ -4,9 +4,7 @@ import { config } from "./config";
 
 export const useOvermind = createHook<typeof config>();
 
-export const overmind = createOvermind(config, {
-  devtools: false,
-});
+export const overmind = createOvermind(config);
 
 declare module "overmind" {
   interface Config extends IConfig<typeof config> {}

--- a/src/overmind/state.ts
+++ b/src/overmind/state.ts
@@ -5,8 +5,10 @@ export enum AppMode {
 
 export type State = {
   mode: AppMode;
+  columns: BoardColumn[];
 };
 
 export const state: State = {
   mode: AppMode.vote,
+  columns: [],
 };


### PR DESCRIPTION
1. Use Overmind to manage the state of which columns are displayed on the board (does not keep track of the cards on a column though).
2. Update how sessions are stored so that they are associated with a boardId.
3. Emit an event per session when a card or column is updated so that each session can respond and update the remaining star count for the specific board and session.